### PR TITLE
feat: support iCloud in China

### DIFF
--- a/src/iCloudClient.ts
+++ b/src/iCloudClient.ts
@@ -1,4 +1,4 @@
-import { getBrowserStorageValue, setBrowserStorageValue, COUNTRY_KEYS } from './storage';
+import { getBrowserStorageValue, COUNTRY_KEYS } from './storage';
 
 export class UnsuccessfulRequestError extends Error {}
 

--- a/src/iCloudClient.ts
+++ b/src/iCloudClient.ts
@@ -57,7 +57,6 @@ class ICloudClient {
   public async isAuthenticated(): Promise<boolean> {
     try {
       this.country = await getBrowserStorageValue<Country>(COUNTRY_KEYS) || 'default'
-      console.log(':: 1', this.country)
       await this.validateToken();
       return true;
     } catch {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,7 +32,10 @@
     "webRequest",
     "notifications"
   ],
-  "host_permissions": ["https://*.icloud.com/*"],
+  "host_permissions": [
+    "https://*.icloud.com/*",
+    "https://*.icloud.com.cn/*"
+  ],
   "icons": {
     "16": "icon-16.png",
     "32": "icon-32.png",

--- a/src/rules.json
+++ b/src/rules.json
@@ -22,5 +22,29 @@
       "resourceTypes": ["xmlhttprequest"],
       "excludedInitiatorDomains": ["apple.com", "icloud.com"]
     }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "Origin",
+          "operation": "set",
+          "value": "https://www.icloud.com.cn"
+        },
+        {
+          "header": "Referer",
+          "operation": "set",
+          "value": "https://www.icloud.com.cn/"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "|https://*.icloud.com.cn/*",
+      "resourceTypes": ["xmlhttprequest"],
+      "excludedInitiatorDomains": ["apple.com", "icloud.com.cn"]
+    }
   }
 ]

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,6 +2,7 @@ import browser from 'webextension-polyfill';
 
 export const POPUP_STATE_STORAGE_KEYS = ['iCloudHmePopupState'];
 export const OPTIONS_STORAGE_KEYS = ['iCloudHmeOptions'];
+export const COUNTRY_KEYS = ['country'];
 
 export async function getBrowserStorageValue<T>(
   keys: string[]

--- a/src/webRequestUtils.ts
+++ b/src/webRequestUtils.ts
@@ -20,19 +20,26 @@ export const setupBlockingWebRequestListeners = () => {
           (header) => !['referer', 'origin'].includes(header.name.toLowerCase())
         ) || [];
 
+      const suffix = documentUrl?.match(/icloud.com(\.\w+)/)?.[1] || '';
+
       modifiedHeaders.push({
         name: 'Referer',
-        value: 'https://www.icloud.com/',
+        value: `https://www.icloud.com${suffix}/`,
       });
       modifiedHeaders.push({
         name: 'Origin',
-        value: 'https://www.icloud.com',
+        value: `https://www.icloud.com${suffix}`,
       });
 
       return { requestHeaders: modifiedHeaders };
     },
     {
-      urls: [`${ICloudClient.setupUrl}/*`, 'https://*.icloud.com/v*/hme/*'],
+      urls: [
+        `${ICloudClient.setupUrl.default}/*`,
+        `${ICloudClient.setupUrl.CN}/*`,
+         'https://*.icloud.com/v*/hme/*',
+         'https://*.icloud.com.cn/v*/hme/*',
+      ],
     },
     ['requestHeaders', 'blocking']
   );

--- a/src/webRequestUtils.ts
+++ b/src/webRequestUtils.ts
@@ -3,7 +3,7 @@ import ICloudClient from './iCloudClient';
 
 export const setupBlockingWebRequestListeners = () => {
   browser.webRequest.onBeforeSendHeaders.addListener(
-    ({ requestHeaders, documentUrl, originUrl, initiator }) => {
+    ({ requestHeaders, documentUrl, originUrl, initiator, url, }) => {
       const initiatedByTheExtension = [documentUrl, originUrl, initiator].some(
         (url) =>
           url?.includes(browser.runtime.id) ||
@@ -20,7 +20,7 @@ export const setupBlockingWebRequestListeners = () => {
           (header) => !['referer', 'origin'].includes(header.name.toLowerCase())
         ) || [];
 
-      const suffix = documentUrl?.match(/icloud.com(\.\w+)/)?.[1] || '';
+      const suffix = url.match(/icloud.com(\.\w+)/)?.[1] || '';
 
       modifiedHeaders.push({
         name: 'Referer',


### PR DESCRIPTION
Closes #34 

Chinese iCloud uses a different domain (icloud.com.cn) instead of (icloud.com), this PR aims to support it.

## Test Plan

1. You need a Chinese Apple ID
2. Login https://www.icloud.com.cn/
3. Everything works as expected
4. Login https://www.icloud.com
5. It works as before