### PR TITLE
Context menu item is persisted across Firefox restarts (fixes: #57)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icloud-hide-my-email-browser-extension",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Cross-browser extension enabling the usage of iCloud's Hide My Email service.",
   "license": "MIT",
   "author": "dedoussis",


### PR DESCRIPTION
Fixes #57 

On firefox the context menu item is now created each time the background script is loaded.