### PR TITLE
Ability reserve email on generate

### DIFF
--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -153,37 +153,50 @@ const Disclaimer = () => {
   );
 };
 
-const AutofillForm = () => {
+const SettingsForm = () => {
   const [options, setOptions] = useBrowserStorageState(
     'iCloudHmeOptions',
     DEFAULT_STORE.iCloudHmeOptions
   );
 
+  const settingsCheckBox = ([key, value]: [string, boolean]) => <div className="flex items-center mb-3" key={key}>
+    <input
+      onChange={() => {
+        if (key in options.autofill) { // Handle nested autofill options
+          setOptions({
+            ...options,
+            autofill: { ...options.autofill, [key]: !value },
+          });
+        } else { // Handle top-level options
+          setOptions({
+            ...options,
+            [key]: !value,
+          });
+        }
+      }}
+      checked={value}
+      id={`checkbox-${key}`}
+      type="checkbox"
+      name={`checkbox-${key}`}
+      className="cursor-pointer w-4 h-4 accent-gray-900 hover:accent-gray-500"
+    />
+    <label
+      htmlFor={`checkbox-${key}`}
+      className="cursor-pointer ml-2 text-gray-900"
+    >
+      {startCase(key)}
+    </label>
+  </div>
+
   return (
     <form className="space-y-3">
+      <h4 className="font-bold text-md mb-4">Autofill</h4>
       {Object.entries(options.autofill).map(([key, value]) => (
-        <div className="flex items-center mb-3" key={key}>
-          <input
-            onChange={() =>
-              setOptions({
-                ...options,
-                autofill: { ...options.autofill, [key]: !value },
-              })
-            }
-            checked={value}
-            id={`checkbox-${key}`}
-            type="checkbox"
-            name={`checkbox-${key}`}
-            className="cursor-pointer w-4 h-4 accent-gray-900 hover:accent-gray-500"
-          />
-          <label
-            htmlFor={`checkbox-${key}`}
-            className="cursor-pointer ml-2 text-gray-900"
-          >
-            {startCase(key)}
-          </label>
-        </div>
+        settingsCheckBox([key, value])
       ))}
+
+      <h4 className="font-bold text-md mb-4">Other</h4>
+      {settingsCheckBox(["useEmailOnGenerate", options.useEmailOnGenerate])}
     </form>
   );
 };
@@ -201,8 +214,8 @@ const Options = () => {
           <SelectFwdToForm />
         </div>
         <div>
-          <h3 className="font-bold text-lg mb-3">Autofill</h3>
-          <AutofillForm />
+          <h3 className="font-bold text-lg mb-3">Settings</h3>
+          <SettingsForm />
         </div>
       </TitledComponent>
     </div>

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -9,6 +9,7 @@ export type Autofill = {
 
 export type Options = {
   autofill: Autofill;
+  useEmailOnGenerate: boolean;
 };
 
 export type Store = {
@@ -27,6 +28,7 @@ export const DEFAULT_STORE = {
       button: true,
       contextMenu: true,
     },
+    useEmailOnGenerate: false
   },
   clientState: undefined,
 };


### PR DESCRIPTION
Thanks for this extension, wanted to contribute additional functionality that I was looking for. Happy for any modifications/feedback on PR.

# Changes

Adds ability to reserve email upon generate (clicking the extension icon)
- Minor refactors on settings checkbox buttons (`settingsCheckBox`) and reserve email logic (`reserveEmail`) to allow these components to be reused for this feature

Context: I use HME to adhoc generate new emails, and didn't realize you needed to click "Use" to reserve the email. This saves me a one click!

# Testing

Settings menu updates correctly
<img width="456" alt="image" src="https://github.com/user-attachments/assets/a652e689-c059-4b79-b74d-49b0a42dd77f" />

Reserve functionality occurs when new email generated (also on regeneration via blue button)
<img width="411" alt="image" src="https://github.com/user-attachments/assets/0f7a2837-11c4-4428-8658-99a1b6e049ef" />

